### PR TITLE
Send transaction to proper proxyAdmin address

### DIFF
--- a/src/SafeUpgrades.tsx
+++ b/src/SafeUpgrades.tsx
@@ -37,7 +37,7 @@ const SafeUpgrades: React.FC<SafeUpgradesProps> = ({ safe, ethereum }) => {
           return err("This proxy's admin is not managed by this Safe")
         }
 
-        setProxyAdminAddress(admin.admin.address.toString())
+        setProxyAdminAddress(admin.address.toString())
 
       } else {
         return err("This proxy's admin is not managed by any address")


### PR DESCRIPTION
When the Proxy is managed by a ProxyAdmin that in turn is managed by the user's Gnosis Safe multisig, the upgrade transaction is sent to the Safe multisig contract instead of the ProxyAdmin.

This PR fixes this bug.